### PR TITLE
fixing the query formatting

### DIFF
--- a/server/controllers/homeController.js
+++ b/server/controllers/homeController.js
@@ -5,7 +5,7 @@ exports.getDevices = (req, res, next) => {
   const homeId = req.params.id;
   logger.info('HomeId in getDevices: ', homeId);
 
-  db.query('SELECT ${column~} FROM ${table~} where houseId={home}', {
+  db.query('SELECT ${column^} FROM ${table~} where houseId=${home}', {
     column: '*',
     table: 'devices',
     home: homeId,


### PR DESCRIPTION
- invalid variable reference in query for `home`
- cannot use `~` syntax for `*`, as you will end up with `"*"`, which is an invalid query syntax. Syntax `~` can be used for any SQL name, but `*` isn't an SQL name, as it cannot be wrapped into `""` (double quotes).
